### PR TITLE
OSX filesystem support

### DIFF
--- a/bin/build.dart
+++ b/bin/build.dart
@@ -42,24 +42,31 @@ packageApp() {
   copyDirectory(electronDir, 'dist/${os}-${arch}');
   
   print('Renaming executable');
-  File electronBin;
-  if (os == WIN)
+  var electronBin;
+  if (os == WIN) {
     electronBin = new File('dist/${os}-${arch}/electron.exe');
-  else
+    electronBin.rename(electronBin.path.replaceAll('electron', package['name']));
+  } else if (os == OSX) {
+    electronBin = new Directory('dist/${os}-${arch}/Electron.app');
+    electronBin.rename(electronBin.path.replaceAll('Electron', package['name']));
+  } else {
     electronBin = new File('dist/${os}-${arch}/electron');
-  electronBin.rename(electronBin.path.replaceAll('electron', package['name']));
+    electronBin.rename(electronBin.path.replaceAll('electron', package['name']));
+  }
 
-  if (os == LINUX || os == OSX){
+  if (os == LINUX){
     print('Updating file permissions.');
     Process.runSync('chmod', ['777', 'dist/${os}-${arch}/${package['name']}']);
+  } else if (os == OSX) {
+    print('Updating file permissions.');
+    Process.runSync('chmod', ['777', 'dist/${os}-${arch}/${package['name']}.app']);
   }
   
   // Moving built App.
   Directory app = new Directory('build/web');
-  
-  
+
   if (os == WIN || os == LINUX)
     copyDirectory(app, 'dist/${os}-${arch}/resources/app');
   else if (os == OSX)
-    copyDirectory(app, 'dist/${os}-${arch}/Electron.app/Contents/Resources/app');
+    copyDirectory(app, 'dist/${os}-${arch}/${package['name']}.app/Contents/Resources/app');
 }

--- a/bin/src/utils.dart
+++ b/bin/src/utils.dart
@@ -62,12 +62,24 @@ detectOS() {
 
 /// Copy a [Directory]'s contents to a [String] path.
 copyDirectory(Directory from, String to) {
-  for (File file in from.listSync(recursive: true).where((e) => e is File)) {
-    
-    List data = file.readAsBytesSync();
-    
-    new File(file.path.replaceAll(from.path, to))
-      ..createSync(recursive: true)
-      ..writeAsBytes(data);
+  if (os == OSX){
+    // Symlinks inside the Electron app break on a naive copy.
+    // Just use native ops for now.
+    ProcessResult results = Process.runSync(
+        'mkdir',
+        ['-p', './${to}']
+    );
+    results = Process.runSync(
+        'cp',
+        ['-r', './${from.path}/', './${to}']
+    );
+  } else {
+    for (File file in from.listSync(recursive: true).where((e) => e is File)) {
+      List data = file.readAsBytesSync();
+
+      new File(file.path.replaceAll(from.path, to))
+        ..createSync(recursive: true)
+        ..writeAsBytes(data);
+    }
   }
 }

--- a/bin/src/utils.dart
+++ b/bin/src/utils.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import '../../packages/args/args.dart';
 
-String version = '0.25.1';
+String version = '0.27.2';
 String os;
 String arch;
 


### PR DESCRIPTION
Hi!  I've added some code to handle OSX specific file copying.  The Dart libs don't handle copying symlinks well and the archive lib has a similar problem.  For OSX, I think it may just be better to use the native CLI tools "cp" and "unzip" to get around this for now.

I also bumped up the hard coded electron version.

Cheers! 